### PR TITLE
Feat : 로그인 pw정보없이 자격증명 구현

### DIFF
--- a/src/main/java/com/semo/semo/domain/user/controller/UserController.java
+++ b/src/main/java/com/semo/semo/domain/user/controller/UserController.java
@@ -21,8 +21,8 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.CREATED).body(userService.signup(request));
     }
 
-//    @PostMapping("/login")
-//    public ResponseEntity<UserLoginRes> login(@RequestBody UserLoginReq request){
-//        return ResponseEntity.status(HttpStatus.OK).body(userService.login(request));
-//    }
+    @PostMapping("/login")
+    public ResponseEntity<UserLoginRes> login(@RequestBody UserLoginReq request){
+        return ResponseEntity.status(HttpStatus.OK).body(userService.login(request));
+    }
 }

--- a/src/main/java/com/semo/semo/domain/user/controller/UserController.java
+++ b/src/main/java/com/semo/semo/domain/user/controller/UserController.java
@@ -21,6 +21,11 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.CREATED).body(userService.signup(request));
     }
 
+    @PostMapping("/signupAdmin")
+    public ResponseEntity<UserSignupRes> signupAdmin(@RequestBody UserSignupReq request){
+        return ResponseEntity.status(HttpStatus.CREATED).body(userService.signupAdmin(request));
+    }
+
     @PostMapping("/login")
     public ResponseEntity<UserLoginRes> login(@RequestBody UserLoginReq request){
         return ResponseEntity.status(HttpStatus.OK).body(userService.login(request));

--- a/src/main/java/com/semo/semo/domain/user/model/entity/User.java
+++ b/src/main/java/com/semo/semo/domain/user/model/entity/User.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -36,6 +37,7 @@ public class User implements UserDetails {
     private String role = "ROLE_USER";
 
     @Column(name = "refresh_token", columnDefinition = "text")
+    @Setter
     private String refreshToken;
 
     @Column(name="created_at", columnDefinition = "timestamp", nullable = false)

--- a/src/main/java/com/semo/semo/domain/user/model/request/UserSignupReq.java
+++ b/src/main/java/com/semo/semo/domain/user/model/request/UserSignupReq.java
@@ -9,5 +9,5 @@ public class UserSignupReq {
     private String pw;
     private String name;
     private String nickname;
-    private String role;
+
 }

--- a/src/main/java/com/semo/semo/domain/user/model/response/UserLoginRes.java
+++ b/src/main/java/com/semo/semo/domain/user/model/response/UserLoginRes.java
@@ -10,4 +10,6 @@ import lombok.Getter;
 public class UserLoginRes {
     private String id;
     private String nickname;
+    private String accessToken;
+    private String refreshToken;
 }

--- a/src/main/java/com/semo/semo/domain/user/service/UserService.java
+++ b/src/main/java/com/semo/semo/domain/user/service/UserService.java
@@ -8,18 +8,19 @@ import com.semo.semo.domain.user.model.response.UserSignupRes;
 import com.semo.semo.domain.user.repository.UserRepository;
 import com.semo.semo.global.error.CustomException;
 import com.semo.semo.global.error.ErrorCode;
+import com.semo.semo.global.utils.JwtUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +28,7 @@ import java.util.Map;
 @Slf4j
 public class UserService {
     private final UserRepository userRepository;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
 
     public UserSignupRes signup(UserSignupReq request) {
         // 중복 체크
@@ -71,6 +73,61 @@ public class UserService {
 
                 User savedUser = userRepository.save(user);
                 return new UserSignupRes().toDto(savedUser);
+            }
+        }
+        throw new CustomException(ErrorCode.AUTH_FAIL);
+    }
+
+    public UserLoginRes login(UserLoginReq request) {
+        // 회원 유무 확인
+        User user = userRepository.findByUserId(request.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // Sejong Auth API 호출 설정
+        RestTemplate restTemplate = new RestTemplate();
+        String url = "https://auth.imsejong.com/auth?method=DosejongSession";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "application/json");
+
+        // 요청 바디 구성
+        Map<String, String> requestBody = new HashMap<>();
+        requestBody.put("id", request.getId());
+        requestBody.put("pw", request.getPw());
+
+        HttpEntity<Map<String, String>> httpEntity = new HttpEntity<>(requestBody, headers);
+
+        // API 호출 및 응답 처리
+        ResponseEntity<Map> response = restTemplate.exchange(url, HttpMethod.POST, httpEntity, Map.class);
+
+        Map<String, Object> responseBody = response.getBody();
+        if (responseBody != null && "success".equals(responseBody.get("msg"))) {
+            Map<String, Object> result = (Map<String, Object>) responseBody.get("result");
+            if (Boolean.TRUE.equals(result.get("is_auth"))) {
+
+//                 //성공 시 로그인 진행
+//                UsernamePasswordAuthenticationToken authenticationToken = new CustomUsernamePasswordAuthenticationToken(request.getId());
+//                authenticationToken.setAuthenticated(true);
+//                 //자격 증명 확인
+//                Authentication authenticate = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+
+//                List<GrantedAuthority> authorities = new ArrayList<>();
+//                authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+//
+//                authenticateWithoutPassword(request.getId(), authorities);
+
+                String authToken = JwtUtils.generateRefreshToken(request.getId());
+
+                // 인증된 사용자를 가져와 refreshToken을 저장
+//                User user = (User) authenticate.getPrincipal();
+
+                user.setRefreshToken(authToken);
+                userRepository.save(user);
+
+                return UserLoginRes.builder()
+                        .id(user.getUserId())
+                        .nickname(user.getNickname())
+                        .build();
             }
         }
         throw new CustomException(ErrorCode.AUTH_FAIL);

--- a/src/main/java/com/semo/semo/domain/user/service/UserService.java
+++ b/src/main/java/com/semo/semo/domain/user/service/UserService.java
@@ -15,10 +15,13 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.*;
 
@@ -67,7 +70,55 @@ public class UserService {
                         .userId(request.getId())
                         .name(request.getName())
                         .nickname(request.getNickname())
-                        .role(request.getRole())
+                        .role("USER")
+                        .major(major)
+                        .build();
+
+                User savedUser = userRepository.save(user);
+                return new UserSignupRes().toDto(savedUser);
+            }
+        }
+        throw new CustomException(ErrorCode.AUTH_FAIL);
+    }
+
+    public UserSignupRes signupAdmin(UserSignupReq request) {
+        // 중복 체크
+        userRepository.findByUserId(request.getId())
+                .ifPresent(x -> {
+                    throw new CustomException(ErrorCode.USER_ALREADY_EXISTS);
+                });
+
+        // Sejong Auth API 호출 설정
+        RestTemplate restTemplate = new RestTemplate();
+        String url = "https://auth.imsejong.com/auth?method=DosejongSession";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "application/json");
+
+        // 요청 바디 구성
+        Map<String, String> requestBody = new HashMap<>();
+        requestBody.put("id", request.getId());
+        requestBody.put("pw", request.getPw());
+
+        HttpEntity<Map<String, String>> httpEntity = new HttpEntity<>(requestBody, headers);
+
+        // API 호출 및 응답 처리
+        ResponseEntity<Map> response = restTemplate.exchange(url, HttpMethod.POST, httpEntity, Map.class);
+
+        Map<String, Object> responseBody = response.getBody();
+        if (responseBody != null && "success".equals(responseBody.get("msg"))) {
+            Map<String, Object> result = (Map<String, Object>) responseBody.get("result");
+            if (Boolean.TRUE.equals(result.get("is_auth"))) {
+
+                Map<String, Object> body = (Map<String, Object>) result.get("body");
+                String major = (String) body.get("major");
+
+                // 성공 시 회원 가입 진행
+                User user = User.builder()
+                        .userId(request.getId())
+                        .name(request.getName())
+                        .nickname(request.getNickname())
+                        .role("ADMIN")
                         .major(major)
                         .build();
 
@@ -105,28 +156,29 @@ public class UserService {
             Map<String, Object> result = (Map<String, Object>) responseBody.get("result");
             if (Boolean.TRUE.equals(result.get("is_auth"))) {
 
-//                 //성공 시 로그인 진행
-//                UsernamePasswordAuthenticationToken authenticationToken = new CustomUsernamePasswordAuthenticationToken(request.getId());
-//                authenticationToken.setAuthenticated(true);
-//                 //자격 증명 확인
-//                Authentication authenticate = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+                // 성공 시 SecurityContext에 인증 정보 설정
+                Authentication auth = new UsernamePasswordAuthenticationToken(
+                        user.getUserId(),
+                        null,
+                        user.getAuthorities()
+                );
 
-//                List<GrantedAuthority> authorities = new ArrayList<>();
-//                authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
-//
-//                authenticateWithoutPassword(request.getId(), authorities);
+                // 인증 정보를 SecurityContext에 저장하여, 이후 요청에서 인증된 사용자 정보로 처리
+                SecurityContextHolder.getContext().setAuthentication(auth);
 
-                String authToken = JwtUtils.generateRefreshToken(request.getId());
+                // JWT 토큰 생성
+                String accessToken = JwtUtils.generateAccessToken(user.getUserId(),user.getRole());
+                String refreshToken = JwtUtils.generateRefreshToken(user.getUserId());
 
-                // 인증된 사용자를 가져와 refreshToken을 저장
-//                User user = (User) authenticate.getPrincipal();
-
-                user.setRefreshToken(authToken);
+                // Refresh 토큰 저장
+                user.setRefreshToken(refreshToken);
                 userRepository.save(user);
 
                 return UserLoginRes.builder()
                         .id(user.getUserId())
                         .nickname(user.getNickname())
+                        .accessToken(accessToken)
+                        .refreshToken(user.getRefreshToken())
                         .build();
             }
         }

--- a/src/main/java/com/semo/semo/global/utils/JwtUtils.java
+++ b/src/main/java/com/semo/semo/global/utils/JwtUtils.java
@@ -34,12 +34,12 @@ public class JwtUtils {
         JWT_SECRET_KEY = key;
     }
 
-    public static String generateAccessToken(String userId, List<String> roles){
+    public static String generateAccessToken(String userId, String role){
 
-        if (roles.contains("ROLE_ADMIN")){
+        if (role.contains("ADMIN")){
             return Jwts.builder()
                     .setSubject(userId)
-                    .claim("roles", roles)
+                    .claim("roles", role)
                     .setIssuedAt(new Date(System.currentTimeMillis()))
                     .setExpiration(new Date(System.currentTimeMillis() + 9999999999L))
                     .signWith(SignatureAlgorithm.HS512, JWT_SECRET_KEY)
@@ -48,7 +48,7 @@ public class JwtUtils {
         else {
             return Jwts.builder()
                     .setSubject(userId)
-                    .claim("roles", roles)
+                    .claim("roles", role)
                     .setIssuedAt(new Date(System.currentTimeMillis()))
                     .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRATION_TIME))
                     .signWith(SignatureAlgorithm.HS512, JWT_SECRET_KEY)
@@ -64,10 +64,10 @@ public class JwtUtils {
                 .compact();
     }
 
-    public static AuthToken generateToken(String userId, List<String> roles) {
+    public static AuthToken generateToken(String userId, String role) {
         return AuthToken.builder()
                 .grantType("Bearer")
-                .accessToken(JwtUtils.generateAccessToken(userId, roles))
+                .accessToken(JwtUtils.generateAccessToken(userId, role))
                 .refreshToken(JwtUtils.generateRefreshToken(userId))
                 .build();
     }


### PR DESCRIPTION
sejoing auth api에서 검증하여 인증 성공 시, 
Authentication 객체를 생성하여 SecurityContextHolder에 인증 정보를 저장하는 방식으로 구현해봤습니다.
확실한 방법인 지는 잘 모르겠어서, 코드리뷰 부탁드립니다.

++) 12/5 수정
- AccessToken 생성 기능 구현, 
- role 속성  String 변환
- 관리자 회원가입 기능 추가
- User db에 refreshToken 저장